### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-templates
+  annotations:
+    github.com/project-slug: CYBERBUGJR/backstage-templates
+spec:
+  type: other
+  lifecycle: unknown
+  owner: test


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [OCSIN - DIN Developer Portal (Backstage) software catalog](https://bcalvet-dh.apps.soca-lab-1.lbdev.etat-ge.ch).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).